### PR TITLE
Real estate bidder first phase -- without GraphQL

### DIFF
--- a/db/dbConnection.go
+++ b/db/dbConnection.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+    "gopkg.in/mgo.v2"
+    "log"
+)
+
+//Mongo session Exported object
+var MgoSession *mgo.Session
+
+func init(){
+    log.Println("Starting mongod session")
+    session, err := mgo.Dial("127.0.0.1") 
+    if err!=nil{
+	panic(err)
+    }
+    MgoSession = session
+}

--- a/db/dbConnection.go
+++ b/db/dbConnection.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-    "gopkg.in/mgo.v2"
+    mgo "gopkg.in/mgo.v2"
     "log"
 )
 
@@ -15,4 +15,23 @@ func init(){
 	panic(err)
     }
     MgoSession = session
+    ensureIndexes()
+}
+
+func ensureIndexes(){
+    ensureIndexOnBidder()
+}
+
+func ensureIndexOnBidder(){
+     index := mgo.Index{
+	Key: []string{"email"},
+	Unique: true,
+	Background: true,
+    }
+
+    err := MgoSession.DB("di_bidder_db").C("bidder").EnsureIndex(index)
+    if err!=nil{
+	log.Fatal("Unique index does not exist on collection : bidder")
+	panic("Unique index does not exist on collection : bidder")
+    }
 }

--- a/models/bidder.go
+++ b/models/bidder.go
@@ -1,9 +1,27 @@
 package models
 
-import "gopkg.in/mgo.v2/bson"
+import (
+    mgo "gopkg.in/mgo.v2"
+    "gopkg.in/mgo.v2/bson"
+
+    "log"
+)
+
+const BIDDER_COLLECTION_NAME = "bidder"
 
 type Bidder struct {
-    ID	    bson.ObjectID   `bson : "_id" json : "id"`
+    ID	    bson.ObjectId   `bson : "_id" json : "id"`
     Name    string	    `bson: "name" json : "name"`
     Email   string	    `bson: "email" json : "email"`
+}
+
+func (bidder *Bidder) Insert(session *mgo.Session) error {
+    bidder_collection := session.DB("di_bidder_db").C(BIDDER_COLLECTION_NAME)
+    bidder.ID = bson.NewObjectId()
+
+    err:=bidder_collection.Insert(bidder)
+    if err !=nil{
+	log.Fatalf("Error inserting bidder %s: Error: %s", bidder.Email, err)
+    }
+    return nil
 }

--- a/models/bidder.go
+++ b/models/bidder.go
@@ -1,0 +1,9 @@
+package models
+
+import "gopkg.in/mgo.v2/bson"
+
+type Bidder struct {
+    ID	    bson.ObjectID   `bson : "_id" json : "id"`
+    Name    string	    `bson: "name" json : "name"`
+    Email   string	    `bson: "email" json : "email"`
+}

--- a/models/real_estate.go
+++ b/models/real_estate.go
@@ -123,7 +123,7 @@ func PlaceBid(session *mgo.Session, re *RealEstate, bidder_email string, bid_amo
 
 func (re *RealEstate) GetBidWinner(session *mgo.Session) (string, float64, error){
     real_estate_collection := session.DB("di_bidder_db").C(REAL_ESTATE_COLLECTION_NAME)
-    var fetched_re *RealEstate
+    fetched_re := &RealEstate{}
 
     err := real_estate_collection.Find(bson.M{"_id":re.ID}).One(fetched_re)
     if err!=nil{

--- a/models/real_estate.go
+++ b/models/real_estate.go
@@ -1,0 +1,146 @@
+package models
+
+import (
+    "log"
+    "errors"
+    mgo "gopkg.in/mgo.v2"
+    "gopkg.in/mgo.v2/bson"
+
+)
+
+const REAL_ESTATE_COLLECTION_NAME = "real_estate"
+
+type BidderBidMap struct{
+    BidderEmail	string	`bson:"bidder_email" json:"bidder_email"`
+    BidAmount	float64	`bson:"bid_amount" json:"bid_amount"`
+}
+
+type RealEstate struct{
+    ID			bson.ObjectId   `bson:"_id,omitempty" json:"id"`
+    Description		string		`bson:"description" json:"description"`
+    InitialBid		float64		`bson:"initial_bid" json:"initial_bid"`
+    HighestBidder	BidderBidMap	`bson:"highest_bidder" json:"highest_bidder"`
+    SecondHighestBidder	BidderBidMap	`bson:"second_highest_bidder" json:"second_highest_bidder"`
+    IsSold		bool		`bson:"is_sold" json:"is_sold"`
+}
+
+func (re *RealEstate) Insert(session *mgo.Session) error {
+    real_estate_collection := session.DB("di_bidder_db").C(REAL_ESTATE_COLLECTION_NAME)
+   
+    err:=real_estate_collection.Insert(re)
+    if err !=nil{
+	log.Fatalf("Error inserting real_estate %s: Error: %v", re.Description, err)
+	return err
+    }
+    return nil
+}
+
+func GetRealEstateByID(session *mgo.Session, ID bson.ObjectId) (*RealEstate, error) {
+    real_estate_collection := session.DB("di_bidder_db").C(REAL_ESTATE_COLLECTION_NAME)
+    var re *RealEstate
+
+    err := real_estate_collection.Find(bson.M{"_id":ID}).One(re)
+    if err!=nil{
+	log.Fatalf("Error fetching real estate record with ID : %s Error: %v", ID, err)
+	return nil, err
+    }
+    return re, nil
+}
+
+func (re *RealEstate) SetInitialBid(session *mgo.Session, initial_bid float64) error{
+    real_estate_collection := session.DB("di_bidder_db").C(REAL_ESTATE_COLLECTION_NAME)
+    
+    filter := bson.M{"_id": re.ID}
+    change := bson.M{
+		"$set": bson.M{
+			"initial_bid": initial_bid,
+		},
+	}
+
+	err := real_estate_collection.Update(filter, change)
+	if err!=nil{
+	    log.Fatalf("Error updating real estate record with InitialBid Error: %v", err)
+	    return err
+	}
+	return nil
+}
+
+func PlaceBid(session *mgo.Session, re *RealEstate, bidder_email string, bid_amount float64) error {
+    real_estate_collection := session.DB("di_bidder_db").C(REAL_ESTATE_COLLECTION_NAME)
+   
+    real_estate_fetched := &RealEstate{}   
+    err := real_estate_collection.FindId(re.ID).One(real_estate_fetched)
+    if err!=nil{
+	return err
+    }
+    filter := bson.M{"_id": re.ID}
+    change := bson.M{}
+    
+    if bid_amount < re.InitialBid{
+	log.Println("Bid amount can't be less than inital bid amount")
+	return errors.New("Bid amount can't be less than inital bid amount") 
+    }
+
+    //if it is first bid, set highest and second highest bid to the initial bid
+    if real_estate_fetched.HighestBidder.BidderEmail == ""{
+	change = bson.M{
+	    "$set":bson.M{
+		"highest_bidder.bidder_email": bidder_email,
+		"second_highest_bidder.bidder_email": bidder_email,
+		"highest_bidder.bid_amount" : bid_amount,
+		"second_highest_bidder.bid_amount": bid_amount,
+	    },
+	}
+    } else if real_estate_fetched.HighestBidder.BidAmount < bid_amount{
+	change = bson.M{
+	    "$set":bson.M{
+		"highest_bidder.bidder_email" : bidder_email,
+		"highest_bidder.bid_amount" : bid_amount,
+		"second_highest_bidder.bidder_email" : real_estate_fetched.HighestBidder.BidderEmail,
+		"second_highest_bidder.bid_amount" : real_estate_fetched.HighestBidder.BidAmount,
+	    },
+	}
+    } else if real_estate_fetched.SecondHighestBidder.BidAmount < bid_amount{
+	change = bson.M{
+	    "$set":bson.M{
+		"second_highest_bidder.bidder_email":bidder_email,
+		"second_highest_bidder.bid_amount":bid_amount,
+	    },
+	}
+    } else{
+	log.Println("No change in HighestBidder and SecondHighestBidder for real estate: ", re.ID)
+	return nil
+    }
+
+
+    err = real_estate_collection.Update(filter, change)
+    if err != nil{
+	log.Fatalf("Error updating real estate record having ID: %s Error: %v", re.ID.String(), err)
+	return err
+    }
+    return nil
+}
+
+func (re *RealEstate) GetBidWinner(session *mgo.Session) (string, float64, error){
+    real_estate_collection := session.DB("di_bidder_db").C(REAL_ESTATE_COLLECTION_NAME)
+    var fetched_re *RealEstate
+
+    err := real_estate_collection.Find(bson.M{"_id":re.ID}).One(fetched_re)
+    if err!=nil{
+	log.Fatalf("Error fetching real estate record with ID : %v Error: %v", re.ID, err)
+	return "", 0.0, err
+    }
+    //update is_sold flag
+    filter := bson.M{"_id":re.ID}
+    change := bson.M{
+	"$set":bson.M{
+	    "is_sold":true,
+	},
+    }
+
+    real_estate_collection.Update(filter, change)
+    winner := fetched_re.HighestBidder.BidderEmail
+    amount_to_be_paid := fetched_re.SecondHighestBidder.BidAmount + 0.01
+    return winner, amount_to_be_paid, nil 
+
+}

--- a/models/real_estate.go
+++ b/models/real_estate.go
@@ -5,10 +5,12 @@ import (
     "errors"
     mgo "gopkg.in/mgo.v2"
     "gopkg.in/mgo.v2/bson"
+    "sync"
 
 )
 
 const REAL_ESTATE_COLLECTION_NAME = "real_estate"
+var mutex sync.Mutex
 
 type BidderBidMap struct{
     BidderEmail	string	`bson:"bidder_email" json:"bidder_email"`
@@ -66,6 +68,10 @@ func (re *RealEstate) SetInitialBid(session *mgo.Session, initial_bid float64) e
 }
 
 func PlaceBid(session *mgo.Session, re *RealEstate, bidder_email string, bid_amount float64) error {
+
+    mutex.Lock()
+    defer mutex.Unlock()
+
     real_estate_collection := session.DB("di_bidder_db").C(REAL_ESTATE_COLLECTION_NAME)
    
     real_estate_fetched := &RealEstate{}   

--- a/server.go
+++ b/server.go
@@ -1,0 +1,25 @@
+package main 
+
+import (
+    "fmt"
+    "net/http"
+    "log"
+
+    "github.com/bidder/db"
+    "github.com/gorilla/mux"
+)
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "Setting up server")
+}
+
+func main(){
+    defer db.MgoSession.Close()
+    fmt.Println("Starting go service...")
+    
+    r := mux.NewRouter()
+    r.HandleFunc("/", indexHandler)
+    if err := http.ListenAndServe(":3000", r); err != nil {
+    	log.Fatal(err)
+    }
+}

--- a/tests/real_estate_test.go
+++ b/tests/real_estate_test.go
@@ -7,6 +7,7 @@ import (
      "log"
      "gopkg.in/mgo.v2/bson"
      "github.com/stretchr/testify/assert"
+     "sync"
 )
 
 var testDBSession *mgo.Session
@@ -39,6 +40,8 @@ func TestInsertRealEstate(t *testing.T){
     assert.Nil(t, err)
 }
 
+var wg sync.WaitGroup
+
 func TestPlaceBid(t *testing.T){
     defer tearDown()
     setupConnection()
@@ -53,13 +56,31 @@ func TestPlaceBid(t *testing.T){
 	log.Println("Error inserting real estate: ", err)
     }
 
-    assert.Nil(t, models.PlaceBid(testDBSession, real_estate_new, "bidder1@fakemail.com", 4444))
-    assert.Nil(t,models.PlaceBid(testDBSession, real_estate_new, "bidder2@fakemail.com", 4544))
-    assert.Nil(t,models.PlaceBid(testDBSession, real_estate_new, "bidder3@fakemail.com", 4000))
+    bidders := make(map[string]float64)
+    bidders["bidder1@fakemail.com"] = 4000
+    bidders["bidder2@fakemail.com"] = 4001
+    bidders["bidder3@fakemail.com"] = 4002
+    bidders["bidder4@fakemail.com"] = 4003
+    bidders["bidder5@fakemail.com"] = 4004
+    bidders["bidder6@fakemail.com"] = 4005
+    bidders["bidder7@fakemail.com"] = 4006
+    bidders["bidder8@fakemail.com"] = 4007
+
+
+    for email, bid_amount := range bidders {
+	wg.Add(1)
+	go  call_go_routine_to_place_bid(real_estate_new, email, bid_amount)
+    }
     
+    wg.Wait()
+
     winner_email, bid_amount, err := real_estate_new.GetBidWinner(testDBSession)
     assert.Nil(t, err)
-    assert.Equal(t, "bidder2@fakemail.com", winner_email)
-    assert.Equal(t, 4444.01, bid_amount)
+    assert.Equal(t, "bidder8@fakemail.com", winner_email)
+    assert.Equal(t, 4006.01, bid_amount)
 }
 
+func call_go_routine_to_place_bid(re *models.RealEstate, email string, bid_amount float64){
+    defer wg.Done()
+    models.PlaceBid(testDBSession, re, email, bid_amount)
+}

--- a/tests/real_estate_test.go
+++ b/tests/real_estate_test.go
@@ -1,0 +1,65 @@
+package testing
+
+import (
+    "testing"
+     mgo "gopkg.in/mgo.v2"
+     "github.com/bidder/models"
+     "log"
+     "gopkg.in/mgo.v2/bson"
+     "github.com/stretchr/testify/assert"
+)
+
+var testDBSession *mgo.Session
+
+const testDBName = "di_bidder_db_test"
+
+func setupConnection(){
+    session, err := mgo.Dial("127.0.0.1") 
+    if err!=nil{
+	panic(err)
+    }
+    testDBSession = session
+}
+
+func tearDown(){
+    testDBSession.DB("di_bidder_db").C("real_estate").RemoveAll(nil)
+    testDBSession.Close()
+}
+
+func TestInsertRealEstate(t *testing.T){
+    defer tearDown()
+    setupConnection()
+    real_estate := &models.RealEstate{
+	Description: "Test Description",
+	InitialBid: 2222,
+	ID : bson.NewObjectId(),
+    }
+
+    err := real_estate.Insert(testDBSession)
+    assert.Nil(t, err)
+}
+
+func TestPlaceBid(t *testing.T){
+    defer tearDown()
+    setupConnection()
+    real_estate_new := &models.RealEstate{
+	Description: "Test Description",
+	InitialBid: 2222,
+	ID : bson.NewObjectId(),
+    }
+
+    err := real_estate_new.Insert(testDBSession)
+    if err!=nil{
+	log.Println("Error inserting real estate: ", err)
+    }
+
+    assert.Nil(t, models.PlaceBid(testDBSession, real_estate_new, "bidder1@fakemail.com", 4444))
+    assert.Nil(t,models.PlaceBid(testDBSession, real_estate_new, "bidder2@fakemail.com", 4544))
+    assert.Nil(t,models.PlaceBid(testDBSession, real_estate_new, "bidder3@fakemail.com", 4000))
+    
+    winner_email, bid_amount, err := real_estate_new.GetBidWinner(testDBSession)
+    assert.Nil(t, err)
+    assert.Equal(t, "bidder2@fakemail.com", winner_email)
+    assert.Equal(t, 4444.01, bid_amount)
+}
+


### PR DESCRIPTION
This branch covers following things
- Initial setup
- Creating/Updating/Reading real estate entity
- Placing Bid on a real estate entity
-- Winner will be declared based on second price aution bidding
- Code handles mutual exclusion on the section where above calculations are done

Following packages are used in the code
- mux -- for URL routing
- mgo -- mongoDB driver for GO

**NOTE**
This code has not considered having different configuration files for different environments (eg test, production) hence, you will see same DB being used for unit tests and regular code flow. Will be adding support of config files in next phase.